### PR TITLE
Use `git worktree` for generating the linter baseline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,13 @@ Added
 
 Fixed
 -----
+- Use ``git worktree`` instead of ``git clone`` and ``git checkout`` to set up a
+  temporary working tree for running linters for a baseline in the ``rev1`` revision of
+  the repository.
 
 
-Darker 0.1.0 to 0.7.0
-======================
+Darker 0.1.0 to 1.7.0
+=====================
 
 For changes before the migration of code from Darker to Darkgraylib, see
 `CHANGES.rst in the Darker repository`__.

--- a/src/darkgraylib/git.py
+++ b/src/darkgraylib/git.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
@@ -13,6 +14,7 @@ from subprocess import DEVNULL, PIPE, CalledProcessError, check_output, run  # n
 from typing import (
     Dict,
     Iterable,
+    Iterator,
     List,
     Match,
     Optional,
@@ -473,28 +475,37 @@ def git_get_modified_python_files(
     return {path for path in changed_paths if should_reformat_file(cwd / path)}
 
 
-def git_clone_local(source_repository: Path, revision: str, destination: Path) -> Path:
+@contextmanager
+def git_clone_local(
+    source_repository: Path, revision: str, destination: Path
+) -> Iterator[Path]:
     """Clone a local repository and check out the given revision
 
     :param source_repository: Path to the root of the local repository checkout
     :param revision: The revision to check out, or ``HEAD``
     :param destination: Directory to create for the clone
-    :return: Path to the root of the new clone
+    :return: A context manager which yields the path to the clone
 
     """
-    clone_path = destination / source_repository.name
+    opts = [
+        # By default, `add` refuses to create a new worktree when `<commit-ish>` is
+        # a branch name and is already checked out by another worktree, or if
+        # `<path>` is already assigned to some worktree but is missing (for
+        # instance, if `<path>` was deleted manually). This option overrides these
+        # safeguards. To add a missing but locked worktree path, specify `--force`
+        # twice.
+        # `remove` refuses to remove an unclean worktree unless `--force` is used.
+        # To remove a locked worktree, specify `--force` twice.
+        # https://git-scm.com/docs/git-worktree#_options
+        "--force",
+        "--force",
+        str(destination),
+    ]
     _ = _git_check_output(
-        [
-            "clone",
-            "--quiet",
-            str(source_repository),
-            str(clone_path),
-        ],
-        Path("."),
+        ["worktree", "add", "--quiet", *opts, revision], cwd=source_repository
     )
-    if revision != "HEAD":
-        _ = _git_check_output(["checkout", revision], clone_path)
-    return clone_path
+    yield destination
+    _ = _git_check_output(["worktree", "remove", *opts], cwd=source_repository)
 
 
 def git_get_root(path: Path) -> Optional[Path]:

--- a/src/darkgraylib/tests/test_git.py
+++ b/src/darkgraylib/tests/test_git.py
@@ -866,45 +866,41 @@ def test_git_clone_local_branch(git_repo, tmp_path, branch, expect):
     git_repo.create_branch("third", "HEAD")
     git_repo.add({"a.py": "third"}, commit="third")
 
-    clone = git.git_clone_local(git_repo.root, branch, tmp_path)
+    with git.git_clone_local(git_repo.root, branch, tmp_path / "clone") as clone:
 
-    assert (clone / "a.py").read_text() == expect
+        assert (clone / "a.py").read_text() == expect
 
 
 @pytest.mark.kwparametrize(
-    dict(branch="HEAD", expect_checkout_call=False),
-    dict(branch="mybranch", expect_checkout_call=True),
+    dict(branch="HEAD"),
+    dict(branch="mybranch"),
 )
-def test_git_clone_local_command(git_repo, tmp_path, branch, expect_checkout_call):
+def test_git_clone_local_command(git_repo, tmp_path, branch):
     """``git_clone_local()`` issues the correct Git command and options"""
     git_repo.add({"a.py": "first"}, commit="first")
     git_repo.create_branch("mybranch", "HEAD")
     check_output = Mock(wraps=git.check_output)  # type: ignore[attr-defined]
+    clone = tmp_path / "clone"
+    check_output_opts = dict(
+        cwd=str(git_repo.root), encoding=None, stderr=PIPE, env=ANY
+    )
+    pre_call = call(
+        ["git", "worktree", "add", "--quiet", "--force", "--force", str(clone), branch],
+        **check_output_opts,
+    )
+    post_call = call(
+        ["git", "worktree", "remove", "--force", "--force", str(clone)],
+        **check_output_opts,
+    )
     with patch.object(git, "check_output", check_output):
 
-        clone = git.git_clone_local(git_repo.root, branch, tmp_path)
+        with git.git_clone_local(git_repo.root, branch, clone) as result:
 
-    assert clone == tmp_path / git_repo.root.name
-    expect_calls = [
-        call(
-            ["git", "clone", "--quiet", str(git_repo.root), str(clone)],
-            cwd=".",
-            encoding=None,
-            stderr=PIPE,
-            env=ANY,
-        )
-    ]
-    if expect_checkout_call:
-        expect_calls.append(
-            call(
-                ["git", "checkout", branch],
-                cwd=str(git_repo.root / git_repo.root.name),
-                encoding=None,
-                stderr=PIPE,
-                env=ANY,
-            )
-        )
-    check_output.assert_has_calls(expect_calls)
+            assert result == clone
+
+            check_output.assert_has_calls([pre_call])
+            check_output.reset_mock()
+    check_output.assert_has_calls([post_call])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`actions/checkout@v3` clones a repository in a way which doesn't allow checking out arbitrary branches after making a local clone using `git clone <path1> <path2>`. This effectively broke linting in the Darker action in version 1.7.0.

The fix is to use `git worktree` instead of `git clone` and `git checkout` to create a local copy of the repository.

This was fixed in akaihola/darker#470. Since some of the touched code is moving to `darkgraylib`, the fix is replicated here.