### PR TITLE
Typed packaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Fixed
 - Use ``git worktree`` instead of ``git clone`` and ``git checkout`` to set up a
   temporary working tree for running linters for a baseline in the ``rev1`` revision of
   the repository.
+- Include the ``py.typed`` typing marker in distributions.
 
 
 Darker 0.1.0 to 1.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ python_requires = >=3.7
 [options.packages.find]
 where = src
 
+[options.package_data]
+darkgraylib =
+  py.typed
+
 [options.entry_points]
 pygments.lexers =
     lint_location = darkgraylib.highlighting.lexers:LocationLexer


### PR DESCRIPTION
Include the `py.typed` typing marker in distributions.
