### PR TITLE
Allow `-` as SRC when using `--stdin-filename`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Added
 - Provide ``git_repo`` as a Pytest plugin.
 - Configure the ``ruff`` linting tool.
 - Drop support for Python 3.7.
+- Allow ``-`` as the single source filename when using the ``--stdin-filename`` option.
+  This makes the option compatible with Black.
 
 Removed
 -------

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -92,7 +92,7 @@ def validate_stdin_src(stdin_filename: Optional[str], src: List[str]) -> None:
     """Make sure both ``stdin`` mode and paths/directories are specified"""
     if stdin_filename is None:
         return
-    if len(src) == 0:
+    if len(src) == 0 or src == ["-"]:
         return
     raise ConfigurationError(
         "No Python source files are allowed when using the `stdin-filename` option"

--- a/src/darkgraylib/tests/test_stdin_filename.py
+++ b/src/darkgraylib/tests/test_stdin_filename.py
@@ -103,6 +103,8 @@ pytestmark = pytest.mark.usefixtures("find_project_root_cache_clear")
     ),
     dict(stdin_filename="a.py"),
     dict(stdin_filename="a.py", revision="..:STDIN:"),
+    dict(src=["-"], stdin_filename="a.py"),
+    dict(src=["-"], stdin_filename="a.py", revision="..:STDIN:"),
     dict(
         stdin_filename="a.py",
         revision="..:WORKTREE:",


### PR DESCRIPTION
Fixes #492. Makes Darker behave like Black.

Required:
- [x] merge #12