### PR TITLE
Allow hyphens for option keys in `pyproject.toml`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ Fixed
 - Python 3.12 compatibility in multi-line string scanning.
 - Upgrade ``install-nix-action`` to version 22 in CI to fix an issue with macOS.
 - Fix tests to run on pushes to ``main`` and pull requests for ``main``.
+- Configuration options spelled with hyphens in ``pyproject.toml``
+  (e.g. ``line-length = 88``) are now supported.
+- In debug log output mode, configuration options are now always spelled with hyphens
+  instead of underscores.
 
 
 Darker 0.1.0 to 1.7.0

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -217,7 +217,9 @@ def dump_config(config: BaseConfig, section_name: str) -> str:
     """Return the configuration in TOML format
     :param section_name:
     """
-    dump = toml.dumps(config, encoder=TomlArrayLinesEncoder())
+    dump = toml.dumps(
+        convert_underscores_to_hyphens(config), encoder=TomlArrayLinesEncoder()
+    )
     return f"[tool.{section_name}]\n{dump}"
 
 

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -4,7 +4,7 @@ import logging
 import os
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Iterable, List, Optional, Type, TypedDict, TypeVar, cast
+from typing import Dict, Iterable, List, Optional, Type, TypeVar, TypedDict, Union, cast
 
 import toml
 
@@ -17,6 +17,9 @@ class TomlArrayLinesEncoder(toml.TomlEncoder):  # type: ignore
     def dump_list(self, v: Iterable[object]) -> str:
         """Format a list value"""
         return "[{}\n]".format("".join(f"\n    {self.dump_value(item)}," for item in v))
+
+
+UnvalidatedConfig = Dict[str, Union[List[str], str, bool, int]]
 
 
 class BaseConfig(TypedDict, total=False):

--- a/src/darkgraylib/tests/test_config.py
+++ b/src/darkgraylib/tests/test_config.py
@@ -52,14 +52,20 @@ def test_toml_array_lines_encoder(list_value, expect):
     assert result == expect
 
 
+class OriginTrackingConfig(BaseConfig):
+    """A configuration class that tracks the originating file for the configuration"""
+
+    origin: str
+
+
 @pytest.mark.kwparametrize(
     dict(),  # pylint: disable=use-dict-literal
     dict(cwd="lvl1"),
     dict(cwd="lvl1/lvl2"),
     dict(cwd="has_git", expect={}),
     dict(cwd="has_git/lvl1", expect={}),
-    dict(cwd="has_pyp", expect={"CONFIG_PATH": "has_pyp"}),
-    dict(cwd="has_pyp/lvl1", expect={"CONFIG_PATH": "has_pyp"}),
+    dict(cwd="has_pyp", expect={"config": "has_pyp"}),
+    dict(cwd="has_pyp/lvl1", expect={"config": "has_pyp"}),
     dict(srcs=["root.py"]),
     dict(srcs=["../root.py"], cwd="lvl1"),
     dict(srcs=["../root.py"], cwd="has_git"),
@@ -74,22 +80,22 @@ def test_toml_array_lines_encoder(list_value, expect):
     dict(srcs=["pyp.py", "../lvl1/lvl1.py"], cwd="has_pyp"),
     dict(
         srcs=["has_pyp/lvl1/l1.py", "has_pyp/lvl1b/l1b.py"],
-        expect={"CONFIG_PATH": "has_pyp"},
+        expect={"config": "has_pyp"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="lvl1",
-        expect={"CONFIG_PATH": "has_pyp"},
+        expect={"config": "has_pyp"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="has_git",
-        expect={"CONFIG_PATH": "has_pyp"},
+        expect={"config": "has_pyp"},
     ),
     dict(
         srcs=["lvl1/l1.py", "lvl1b/l1b.py"],
         cwd="has_pyp",
-        expect={"CONFIG_PATH": "has_pyp"},
+        expect={"config": "has_pyp"},
     ),
     dict(
         srcs=["full_example/full.py"],
@@ -100,202 +106,261 @@ def test_toml_array_lines_encoder(list_value, expect):
         },
     ),
     dict(srcs=["stdout_example/dummy.py"], expect={"stdout": True}),
-    dict(confpath="c", expect={"PYP_TOML": 1}),
-    dict(confpath="c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="lvl1", confpath="../c", expect={"PYP_TOML": 1}),
-    dict(cwd="lvl1", confpath="../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="lvl1/lvl2", confpath="../../c", expect={"PYP_TOML": 1}),
-    dict(cwd="lvl1/lvl2", confpath="../../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="has_git", confpath="../c", expect={"PYP_TOML": 1}),
-    dict(cwd="has_git", confpath="../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="has_git/lvl1", confpath="../../c", expect={"PYP_TOML": 1}),
-    dict(cwd="has_git/lvl1", confpath="../../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="has_pyp", confpath="../c", expect={"PYP_TOML": 1}),
-    dict(cwd="has_pyp", confpath="../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(cwd="has_pyp/lvl1", confpath="../../c", expect={"PYP_TOML": 1}),
-    dict(cwd="has_pyp/lvl1", confpath="../../c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(srcs=["root.py"], confpath="c", expect={"PYP_TOML": 1}),
-    dict(srcs=["root.py"], confpath="c/pyproject.toml", expect={"PYP_TOML": 1}),
-    dict(srcs=["../root.py"], cwd="lvl1", confpath="../c", expect={"PYP_TOML": 1}),
+    dict(confpath="c", expect={"origin": "c/pyproject.toml"}),
+    dict(confpath="c/pyproject.toml", expect={"origin": "c/pyproject.toml"}),
+    dict(cwd="lvl1", confpath="../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="lvl1",
+        confpath="../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(cwd="lvl1/lvl2", confpath="../../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="lvl1/lvl2",
+        confpath="../../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(cwd="has_git", confpath="../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="has_git",
+        confpath="../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(cwd="has_git/lvl1", confpath="../../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="has_git/lvl1",
+        confpath="../../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(cwd="has_pyp", confpath="../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="has_pyp",
+        confpath="../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(cwd="has_pyp/lvl1", confpath="../../c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        cwd="has_pyp/lvl1",
+        confpath="../../c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(srcs=["root.py"], confpath="c", expect={"origin": "c/pyproject.toml"}),
+    dict(
+        srcs=["root.py"],
+        confpath="c/pyproject.toml",
+        expect={"origin": "c/pyproject.toml"},
+    ),
+    dict(
+        srcs=["../root.py"],
+        cwd="lvl1",
+        confpath="../c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["../root.py"],
         cwd="lvl1",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["../root.py"], cwd="has_git", confpath="../c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["../root.py"],
+        cwd="has_git",
+        confpath="../c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["../root.py"],
         cwd="has_git",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["../root.py"], cwd="has_pyp", confpath="../c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["../root.py"],
+        cwd="has_pyp",
+        confpath="../c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["../root.py"],
         cwd="has_pyp",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["root.py", "lvl1/lvl1.py"], confpath="c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["root.py", "lvl1/lvl1.py"],
+        confpath="c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["root.py", "lvl1/lvl1.py"],
         confpath="c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "lvl1.py"],
         cwd="lvl1",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "lvl1.py"],
         cwd="lvl1",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "../lvl1/lvl1.py"],
         cwd="has_git",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "../lvl1/lvl1.py"],
         cwd="has_git",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "../lvl1/lvl1.py"],
         cwd="has_pyp",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../root.py", "../lvl1/lvl1.py"],
         cwd="has_pyp",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["has_pyp/pyp.py", "lvl1/lvl1.py"], confpath="c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["has_pyp/pyp.py", "lvl1/lvl1.py"],
+        confpath="c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["has_pyp/pyp.py", "lvl1/lvl1.py"],
         confpath="c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/pyp.py", "lvl1.py"],
         cwd="lvl1",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/pyp.py", "lvl1.py"],
         cwd="lvl1",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/pyp.py", "../lvl1/lvl1.py"],
         cwd="has_git",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/pyp.py", "../lvl1/lvl1.py"],
         cwd="has_git",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["pyp.py", "../lvl1/lvl1.py"],
         cwd="has_pyp",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["pyp.py", "../lvl1/lvl1.py"],
         cwd="has_pyp",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["has_pyp/lvl1/l1.py", "has_pyp/lvl1b/l1b.py"],
         confpath="c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["has_pyp/lvl1/l1.py", "has_pyp/lvl1b/l1b.py"],
         confpath="c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="lvl1",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="lvl1",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="has_git",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["../has_pyp/lvl1/l1.py", "../has_pyp/lvl1b/l1b.py"],
         cwd="has_git",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["lvl1/l1.py", "lvl1b/l1b.py"],
         cwd="has_pyp",
         confpath="../c",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     dict(
         srcs=["lvl1/l1.py", "lvl1b/l1b.py"],
         cwd="has_pyp",
         confpath="../c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["full_example/full.py"], confpath="c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["full_example/full.py"],
+        confpath="c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["full_example/full.py"],
         confpath="c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
-    dict(srcs=["stdout_example/dummy.py"], confpath="c", expect={"PYP_TOML": 1}),
+    dict(
+        srcs=["stdout_example/dummy.py"],
+        confpath="c",
+        expect={"origin": "c/pyproject.toml"},
+    ),
     dict(
         srcs=["stdout_example/dummy.py"],
         confpath="c/pyproject.toml",
-        expect={"PYP_TOML": 1},
+        expect={"origin": "c/pyproject.toml"},
     ),
     srcs=[],
     cwd=".",
     confpath=None,
-    expect={"CONFIG_PATH": "."},
+    expect={"config": "no_pyp"},
 )
 def test_load_config(  # pylint: disable=too-many-arguments
     find_project_root_cache_clear, tmp_path, monkeypatch, srcs, cwd, confpath, expect
 ):
     """``load_config()`` finds and loads configuration based on source file paths"""
     (tmp_path / ".git").mkdir()
-    (tmp_path / "pyproject.toml").write_text('[tool.darkgraylib]\nCONFIG_PATH = "."\n')
+    (tmp_path / "pyproject.toml").write_text('[tool.darkgraylib]\nconfig = "no_pyp"\n')
     (tmp_path / "lvl1/lvl2").mkdir(parents=True)
     (tmp_path / "has_git/.git").mkdir(parents=True)
     (tmp_path / "has_git/lvl1").mkdir()
     (tmp_path / "has_pyp/lvl1").mkdir(parents=True)
     (tmp_path / "has_pyp/pyproject.toml").write_text(
-        '[tool.darkgraylib]\nCONFIG_PATH = "has_pyp"\n'
+        '[tool.darkgraylib]\nconfig = "has_pyp"\n'
     )
     (tmp_path / "full_example").mkdir()
     (tmp_path / "full_example/pyproject.toml").write_text(
@@ -316,10 +381,12 @@ def test_load_config(  # pylint: disable=too-many-arguments
         "[tool.darkgraylib]\nstdout = true\n"
     )
     (tmp_path / "c").mkdir()
-    (tmp_path / "c" / "pyproject.toml").write_text("[tool.darkgraylib]\nPYP_TOML = 1\n")
+    (tmp_path / "c" / "pyproject.toml").write_text(
+        "[tool.darkgraylib]\norigin = 'c/pyproject.toml'\n"
+    )
     monkeypatch.chdir(tmp_path / cwd)
 
-    result = load_config(confpath, srcs, "darkgraylib", BaseConfig)
+    result = load_config(confpath, srcs, "darkgraylib", OriginTrackingConfig)
 
     assert result == expect
 
@@ -434,7 +501,7 @@ def test_get_modified_config(args, expect):
                 "main.py",
             ]
             revision = "master"
-            log_level = "DEBUG"
+            log-level = "DEBUG"
             """
         ),
     ),


### PR DESCRIPTION
Fixes akaihola/darker#502. Ported from akaihola/darker#503.

Also normalizes the `pyproject.toml` dump seen in debug log level to always use hyphens instead of underscores in option keys.