### PR TITLE
Update to `actions/setup-python@v5`

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: pip install 'isort>=5.0.1'
       - uses: wearerequired/lint-action@v2.3.0
         with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: |
           pip install -U \
             black \

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install dependencies for running Pylint
         run: |
           pip install -U \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
       wheel-path: ${{ steps.get-darkgraylib-version.outputs.wheel-path }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install wheel
         run: python -m pip install wheel
       - name: Build wheel distribution
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download wheel uploaded by the build-wheel job
@@ -125,7 +125,7 @@ jobs:
       - build-wheel
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - name: Install twine
         run: python -m pip install twine
       - name: Download wheel uploaded by the build-wheel job

--- a/.github/workflows/pyupgrade.yml
+++ b/.github/workflows/pyupgrade.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: pip install pyupgrade
       - name: Ensure modern Python style using pyupgrade
         # This script is written in a Linux / macos / windows portable way

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: pip install -U pip-tools
       - run: pip-compile setup.cfg
       - run: pip install -U safety

--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
 
       - name: Make sure that `bump_version.py` still finds all version strings
               and that there's a future milestone on GitHub Issues.

--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: 'master'
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install dependencies


### PR DESCRIPTION
This fixes the Node.js 16 deprecation warning.

Ported from akaihola/darker#530.