### PR TITLE
Update `actions/checkout@v3` to `@v4`

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Bandit security check for code
         uses: akaihola/bandit-report-artifacts@use-config

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: codespell-project/actions-codespell@master

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: TrueBrain/actions-flake8@v2
         with:
           plugins: >

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: pip install 'isort>=5.0.1'
       - uses: wearerequired/lint-action@v2.3.0

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: |
           pip install -U \

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install dependencies for running Pylint
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       wheel-path: ${{ steps.get-darkgraylib-version.outputs.wheel-path }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install wheel
         run: python -m pip install wheel
@@ -54,7 +54,7 @@ jobs:
     needs:
       - build-wheel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -100,7 +100,7 @@ jobs:
     needs:
       - build-wheel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -124,7 +124,7 @@ jobs:
     needs:
       - build-wheel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install twine
         run: python -m pip install twine

--- a/.github/workflows/pyupgrade.yml
+++ b/.github/workflows/pyupgrade.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: pip install pyupgrade
       - name: Ensure modern Python style using pyupgrade

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: pip install -U pip-tools
       - run: pip-compile setup.cfg

--- a/.github/workflows/test-bump-version.yml
+++ b/.github/workflows/test-bump-version.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
       - name: Make sure that `bump_version.py` still finds all version strings

--- a/.github/workflows/test-future.yml
+++ b/.github/workflows/test-future.yml
@@ -12,7 +12,7 @@ jobs:
   test-future:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: 'master'
           fetch-depth: 0

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -5,6 +5,6 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Fixed
   override characters.
 - Black 24.2 compatibility by adding our own implementation of
   `darkgraylib.files.find_project_root`.
+- Update `actions/checkout@v3` to `actions/checkout@v4` in CI builds.
 
 
 Darker 0.1.0 to 1.7.0


### PR DESCRIPTION
This gets rid of Node version warnings.