### PR TITLE
Install `darkgray-dev-tools` from PyPI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Install ``darkgray-dev-tools`` from PyPI. They don't allow dependencies from GitHub.
 
 
 1.1.0_ - 2024-03-15
@@ -89,4 +90,6 @@ For changes before the migration of code from Darker to Darkgraylib, see
 
 __ https://github.com/akaihola/darker/blob/master/CHANGES.rst
 
-.. _Unreleased: https://github.com/akaihola/darker/compare/6515b5de...HEAD
+.. _Unreleased: https://github.com/akaihola/darkgraylib/compare/v1.1.0...HEAD
+.. _1.1.0: https://github.com/akaihola/darkgraylib/compare/v1.0.0...v1.1.0
+.. _1.0.0: https://github.com/akaihola/darkgraylib/compare/1.7.0...v1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,7 @@ test =
 release =
     airium>=0.2.3
     click>=8.0.0
-    darkgray-dev-tools @ https://github.com/akaihola/darkgray-dev-tools/archive/refs/heads/main.zip
+    darkgray-dev-tools~=0.0.1
     defusedxml>=0.7.1
     requests_cache>=0.7
 


### PR DESCRIPTION
PyPI doesn't allow dependencies from GitHub zip files.