### PR TITLE
"Configuration loaded" hook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ These features will be included in the next release:
 
 Added
 -----
+- An optional hook to be called after loading the configuration file. Used by Darker to
+  show deprecation warnings for configuration options.
 
 Fixed
 -----

--- a/src/darkgraylib/command_line.py
+++ b/src/darkgraylib/command_line.py
@@ -1,9 +1,11 @@
 """Command line parsing for the ``darker`` and ``graylint`` binaries."""
 
+from __future__ import annotations
+
 import sys
 from argparse import SUPPRESS, ArgumentParser, Namespace
 from functools import partial
-from typing import Any, List, Optional, Tuple, Type, TypeVar, Protocol
+from typing import Any, Callable, List, Optional, Protocol, Tuple, Type, TypeVar
 
 from darkgraylib import help as hlp
 from darkgraylib.argparse_helpers import (
@@ -113,6 +115,7 @@ def parse_command_line(
     argv: Optional[List[str]],
     section_name: str,
     config_type: Type[T],
+    load_config_hook: Callable[[T], None] | None = None,
 ) -> Tuple[Namespace, T, T]:
     """Return the parsed command line, using defaults from a configuration file
 
@@ -129,6 +132,9 @@ def parse_command_line(
     :param config_type: The type of the configuration object to be returned. For Darker,
                         this should be ``DarkerConfig``, for Graylint
                         ``GraylintConfig``.
+    :param load_config_hook: A hook to call after loading the configuration file. This
+                             is used to warn about configuration options which are
+                             deprecated in the configuration file.
     :return: A tuple of the parsed command line, the effective configuration, and the
              set of modified configuration options from the defaults.
 
@@ -146,6 +152,8 @@ def parse_command_line(
     #    directory if no paths were given. Load Darker or Graylint configuration from
     #    it.
     pyproject_config = load_config(args.config, args.src, section_name, config_type)
+    if load_config_hook:
+        load_config_hook(pyproject_config)
 
     # 3. The PY_COLORS, NO_COLOR and FORCE_COLOR environment variables override the
     #    `--color` command line option.

--- a/src/darkgraylib/command_line.py
+++ b/src/darkgraylib/command_line.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import sys
 from argparse import SUPPRESS, ArgumentParser, Namespace
 from functools import partial
-from typing import Any, Callable, List, Optional, Protocol, Tuple, Type, TypeVar
+from typing import Any, Callable, Protocol, TypeVar
 
 from darkgraylib import help as hlp
 from darkgraylib.argparse_helpers import (
     LogLevelAction,
     NewlinePreservingFormatter,
-    OptionsForReadmeAction, UpdateReadmeAction, VerifyReadmeAction,
+    OptionsForReadmeAction,
+    UpdateReadmeAction,
+    VerifyReadmeAction,
 )
 from darkgraylib.config import (
     BaseConfig,
@@ -85,7 +87,10 @@ def make_argument_parser(
 
 
 def add_parser_argument(
-    parser: ArgumentParser, help_text: Optional[str], *name_or_flags: str, **kwargs: Any
+    parser: ArgumentParser,
+    help_text: str | None,
+    *name_or_flags: str,
+    **kwargs: Any,  # noqa: ANN401
 ) -> None:
     """Add an argument to the parser
 
@@ -112,11 +117,11 @@ class ArgumentParserFactory(Protocol):  # pylint: disable=too-few-public-methods
 
 def parse_command_line(
     argument_parser_factory: ArgumentParserFactory,
-    argv: Optional[List[str]],
+    argv: list[str] | None,
     section_name: str,
-    config_type: Type[T],
+    config_type: type[T],
     load_config_hook: Callable[[T], None] | None = None,
-) -> Tuple[Namespace, T, T]:
+) -> tuple[Namespace, T, T]:
     """Return the parsed command line, using defaults from a configuration file
 
     Also return the effective configuration which combines defaults, the configuration

--- a/src/darkgraylib/tests/test_command_line.py
+++ b/src/darkgraylib/tests/test_command_line.py
@@ -1,7 +1,8 @@
 """Unit tests for `darkgraylib.command_line` and `darkgraylib.main`."""
 
 import os
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 import toml
@@ -300,3 +301,17 @@ def test_parse_command_line(
             assert (
                 modified_cfg[modified_option] == expect_modified_value  # type: ignore
             )
+
+
+def test_parse_command_line_load_config_hook_called(tmp_path, monkeypatch):
+    """The load configuration hook is called correctly."""
+    monkeypatch.chdir(tmp_path)
+    with Path("pyproject.toml").open("w") as pyproject:
+        toml.dump({"tool": {"darkgraylib": {"revision": "main"}}}, pyproject)
+    hook_mock = Mock()
+
+    parse_command_line(
+        make_test_argument_parser, ["x.py"], "darkgraylib", BaseConfig, hook_mock,
+    )
+
+    hook_mock.assert_called_once_with({"revision": "main"})


### PR DESCRIPTION
The hook function, if provided, is called after the configuration file has been loaded. Darker uses this to display warnings for configuration file options which have been deprecated.

This is required to fix akaihola/darker#447.