### PR TITLE
Replace `utcfromtimestamp` with `fromtimestamp`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ The ``release_tools/update_contributors.py`` script was moved to the
 Fixed
 -----
 - Badge links in the README on GitHub.
+- Replace calls to the deprecated `datetime.datetime.utcfromtimestamp` method with
+  `datetime.datetime.fromtimestamp`, passing it the timezone `datetime.timezone.utc`.
 
 
 1.1.1_ - 2024-03-27

--- a/src/darkgraylib/git.py
+++ b/src/darkgraylib/git.py
@@ -7,7 +7,7 @@ import shlex
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, check_output  # nosec
@@ -78,7 +78,7 @@ def git_get_mtime_at_commit(path: Path, revision: str, cwd: Path) -> str:
     """
     cmd = ["log", "-1", "--format=%ct", revision, "--", path.as_posix()]
     lines = git_check_output_lines(cmd, cwd)
-    return datetime.utcfromtimestamp(int(lines[0])).strftime(GIT_DATEFORMAT)
+    return datetime.fromtimestamp(int(lines[0]), timezone.utc).strftime(GIT_DATEFORMAT)
 
 
 def git_get_content_at_revision(path: Path, revision: str, cwd: Path) -> TextDocument:

--- a/src/darkgraylib/utils.py
+++ b/src/darkgraylib/utils.py
@@ -3,7 +3,7 @@
 import io
 import sys
 import tokenize
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import chain
 from pathlib import Path
 from typing import Iterable, Tuple
@@ -125,7 +125,9 @@ class TextDocument:
         Also store the last modification time of the file.
 
         """
-        mtime = datetime.utcfromtimestamp(path.stat().st_mtime).strftime(GIT_DATEFORMAT)
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).strftime(
+            GIT_DATEFORMAT
+        )
         with path.open("rb") as srcbuf:
             return cls.from_bytes(srcbuf.read(), mtime)
 


### PR DESCRIPTION
`datetime.datetime.utcfromtimestamp` is deprecated in Python 3.12. Use `datetime.datetime.fromtimestamp(..., datetime.timezone.utc)`.

Fixes #47.