### PR TITLE
Show correct section name in config dumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- The ``darker -vv`` and ``graylint -vv`` verbosity options now show the correct section
+  name ``[tool.darker]`` and ``[tool.graylint]`` in the configuration dump.
 
 
 1.2.0_ - 2024-04-01


### PR DESCRIPTION
`darker -vv` used to output:

```toml
# Effective configuration:

[tool.darkgraylib]
# [...]


# Configuration options which differ from defaults:

[tool.darkgraylib]
# [...]
```

This patch corrects it to:

```toml
# Effective configuration:

[tool.darker]
# [...]


# Configuration options which differ from defaults:

[tool.darker]
# [...]
```

The same fix applies to Graylint.

Darker and Graylint don't need to change anything since the module of the calling function is used to determine the section name. There is an explicit option which Darker and Graylint should start using in the future to pass in the section name. After that the code for inferring the section name from the calling function should be removed.