### PR TITLE
The config dump section name is now required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ These features will be included in the next release:
 Added
 -----
 
+Removed
+-------
+- The config dump section name is now required and is not inferred from the caller.
+
 Fixed
 -----
 - The ``darker -vv`` and ``graylint -vv`` verbosity options now show the correct section


### PR DESCRIPTION
It's no longer inferred from the calling function.

This requires a minor version bump.