### PR TITLE
Report version of calling module not self

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Removed
 Fixed
 -----
 - Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
+- The `~darkgraylib.command_line.make_argument_parser` function now has a ``version``
+  argument which defaults to Darkgraylib's own version. This allows Darker and Graylint
+  to correctly report their own version when called with the ``--version`` option.
 
 
 1.2.1_ - 2024-04-21

--- a/src/darkgraylib/command_line.py
+++ b/src/darkgraylib/command_line.py
@@ -27,7 +27,11 @@ from darkgraylib.version import __version__
 
 
 def make_argument_parser(
-    require_src: bool, application: str, description: str, config_help: str
+    require_src: bool,
+    application: str,
+    description: str,
+    config_help: str,
+    version: str = __version__,
 ) -> ArgumentParser:
     """Create the argument parser object
 
@@ -75,7 +79,7 @@ def make_argument_parser(
         hlp.VERSION.format(application=application),
         "--version",
         action="version",
-        version=__version__,
+        version=version,
     )
     add_arg(hlp.WORKERS, "-W", "--workers", type=int, dest="workers", default=1)
     # A hidden option for printing command lines option in a format suitable for


### PR DESCRIPTION
Darkgraylib would always report its own version instead of the module that was instantiating the argument parser. By adding a `version` argument to the `make_argument_parser` method which defaults to darkgraylib's own version, the `--version` flag works as expected.

Does however require additional changes to all calling code (darker and graylint) which has been done in the linked PRs