### PR TITLE
Fix CI compatibility with Pip >= 24.1

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Install dependencies for running Pylint
         run: |
           pip install -U \
-            airium \
             defusedxml \
             pygments \
             pylint \

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Removed
 
 Fixed
 -----
+- Update ``darkgray-dev-tools`` for Pip >= 24.1 compatibility.
 
 
 1.2.1_ - 2024-04-21

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -3,7 +3,6 @@
 # still works against oldest supported versions of both the Python
 # interpreter and Python ependencies. Keep this up-to-date with minimum
 # versions in `setup.cfg`.
-airium==0.2.3
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ color =
     Pygments>=2.4.0
 test =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
-    airium>=0.2.3
     click>=8.0.0
     cryptography>=3.3.2  # through twine, fixes CVE-2020-36242
     defusedxml>=0.7.1
@@ -74,7 +73,7 @@ test =
     urllib3>=1.25.9  # through requests-cache and twine, fixes CVE-2020-26137
     wheel>=0.21.0
 release =
-    darkgray-dev-tools~=0.1.0
+    darkgray-dev-tools~=0.1.1
 
 [flake8]
 # Line length according to Black rules


### PR DESCRIPTION
Airium 0.2.3 to 0.2.5 wheel metadata isn't supported by Pip >= 24.1. Airium 0.2.6 fixes the metadata. `darkgray-dev-tools==0.1.1 updates Airium to version 0.2.6.

This is similar to akaihola/darker#597.