### PR TITLE
Use Graylint for linting this repo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ These features will be included in the next release:
 
 Added
 -----
+- The command ``graylint --config=check-darkgraylib.toml`` now runs Flake8_, Mypy_,
+  pydocstyle_, Pylint_ and Ruff_ on modified lines in Python files. Those tools are
+  included in the ``[test]`` extra.
 
 Removed
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,14 @@ src = [
 ]
 revision = "origin/main..."
 isort = true
+
+[tool.graylint]
+src = [
+    "release_tools",
+    "src",
+    "setup.py",
+]
+revision = "origin/main..."
 lint = [
     "flake8",
     "mypy",


### PR DESCRIPTION
Darker no longer runs linters for this repository by default.