### PR TITLE
Avoid Git's dubious ownership error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Added
 
 Fixed
 -----
+- When running Git with a clean environment, keep all environment variables and just
+  override the language.
 
 
 2.0.0_ - 2024-07-31

--- a/src/darkgraylib/git.py
+++ b/src/darkgraylib/git.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from subprocess import PIPE, CalledProcessError, check_output  # nosec
 from typing import Dict, Iterator, List, Match, Optional, Tuple, Union, cast, overload
 
-from darkgraylib.utils import GIT_DATEFORMAT, WINDOWS, TextDocument
+from darkgraylib.utils import GIT_DATEFORMAT, TextDocument
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +32,6 @@ COMMIT_RANGE_RE = re.compile(r"(.*?)(\.{2,3})(.*)$")
 WORKTREE = ":WORKTREE:"
 STDIN = ":STDIN:"
 PRE_COMMIT_FROM_TO_REFS = ":PRE-COMMIT:"
-
-# These are the environment variables to use when running Git.
-# See:
-# - https://github.com/git/git/blob/39bf06ad/git-compat-util.h#L566-L585
-# - https://github.com/git/git/blob/39bf06ad/compat/mingw.c#L2740-L2858
-GIT_ENV_VARS = {"HOME", "PATH"} if WINDOWS else {"EUID", "PATH", "SUDO_UID"}
 
 
 def git_get_version() -> Tuple[int, ...]:

--- a/src/darkgraylib/git.py
+++ b/src/darkgraylib/git.py
@@ -243,18 +243,11 @@ def make_git_env() -> Dict[str, str]:
     """Create custom environment variables to use when invoking Git.
 
     This makes sure that:
-    - Git always runs in English
-    - ``$PATH`` is preserved (essential on NixOS)
-    - variables necessary for Git's dubious ownership detection are preserved:
-      - ``$EUID`` and ``$SUDO_UID`` on Unix
-      - ``$HOME`` on Windows
-    - the environment is otherwise cleared
+    - Git always runs in English (``LC_ALL`` is set to ``C.UTF-8``)
+    - The existing environment is preserved
 
     """
-    return {
-        "LC_ALL": "C",
-        **{name: value for name, value in os.environ.items() if name in GIT_ENV_VARS},
-    }
+    return {"LC_ALL": "C.UTF-8", **os.environ}
 
 
 def git_check_output_lines(

--- a/src/darkgraylib/tests/test_git.py
+++ b/src/darkgraylib/tests/test_git.py
@@ -119,7 +119,7 @@ def git_call(cmd, encoding=None):
         cwd=str(Path("/path")),
         encoding=encoding,
         stderr=PIPE,
-        env={"LC_ALL": "C", "PATH": os.environ["PATH"]},
+        env=ANY,
     )
 
 
@@ -453,3 +453,23 @@ def test_git_get_root_not_found(tmp_path, path):
     root = git.git_get_root(tmp_path / path)
 
     assert root is None
+
+
+def test_git_output_in_english(git_repo, monkeypatch):
+    """Git output is in English despite German language environment."""
+    # Set up German language environment
+    german_env = {
+        "LC_ALL": "de_DE.UTF-8",
+        "LC_CTYPE": "de_DE.UTF-8",
+        "LC_MESSAGES": "de_DE.UTF-8",
+        "LANG": "de_DE.UTF-8",
+    }
+    for key, value in german_env.items():
+        monkeypatch.setenv(key, value)
+
+    # Run a Git command and check its output
+    output = git.git_check_output_lines(["status"], git_repo.root)
+
+    # Verify that the output is in English
+    assert "No commits yet" in output
+    assert "Noch keine Commits" not in output


### PR DESCRIPTION
When running Git, don't remove any environment variables. Instead, just override `LC_ALL=C.UTF-8`. Also add a test which verifies that this is sufficient to ensure Git's output is in English.

Fixes akaihola/darker#524
Fixes akaihola/darker#590

---

The original flawed plan was:

~~add some environment variables which are needed to avoid Git's dubious ownership detection:~~
- ~~`$HOME` on Windows/MinGW~~
- ~~`$EUID` and `$SUDO_UID` on Unix~~

~~See:~~
- ~~https://github.com/git/git/blob/39bf06ad/git-compat-util.h#L566-L585~~
- ~~https://github.com/git/git/blob/39bf06ad/compat/mingw.c#L2740-L2858~~