### PR TITLE
Release version 2.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ If applicable, add copy/paste the output or attach a screenshots to help explain
  - Python version [e.g. 3.10.4]
  - Git version [e.g. 2.36.0]
  - Darker or Graylint version [e.g. 1.7.3]
- - Darkgraylib version [e.g. 2.0.0]
+ - Darkgraylib version [e.g. 2.0.1]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Added
 
 Fixed
 -----
+
+
+2.0.1_ - 2024-08-09
+===================
+
+Fixed
+-----
 - When running Git with a clean environment, keep all environment variables and just
   override the language.
 
@@ -201,7 +208,11 @@ For changes before the migration of code from Darker to Darkgraylib, see
 
 __ https://github.com/akaihola/darker/blob/master/CHANGES.rst
 
-.. _Unreleased: https://github.com/akaihola/darkgraylib/compare/v1.3.0...HEAD
+.. _Unreleased: https://github.com/akaihola/darkgraylib/compare/v2.0.1...HEAD
+.. _2.0.1: https://github.com/akaihola/darkgraylib/compare/v2.0.0...v2.0.1
+.. _2.0.0: https://github.com/akaihola/darkgraylib/compare/v1.3.2...v2.0.0
+.. _1.3.2: https://github.com/akaihola/darkgraylib/compare/v1.3.1...v1.3.2
+.. _1.3.1: https://github.com/akaihola/darkgraylib/compare/v1.3.0...v1.3.1
 .. _1.3.0: https://github.com/akaihola/darkgraylib/compare/v1.2.1...v1.3.0
 .. _1.2.1: https://github.com/akaihola/darkgraylib/compare/v1.2.0...v1.2.1
 .. _1.2.0: https://github.com/akaihola/darkgraylib/compare/v1.1.0...v1.2.0

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
 .. |changelog-badge| image:: https://img.shields.io/badge/-change%20log-purple
    :alt: Change log
    :target: https://github.com/akaihola/darkgraylib/blob/main/CHANGES.rst
-.. |next-milestone| image:: https://img.shields.io/github/milestones/progress/akaihola/darkgraylib/12?color=red&label=release%202.0.1
+.. |next-milestone| image:: https://img.shields.io/github/milestones/progress/akaihola/darkgraylib/13?color=red&label=release%202.0.2
    :alt: Next milestone
    :target: https://github.com/akaihola/darkgraylib/milestone/4
 

--- a/src/darkgraylib/version.py
+++ b/src/darkgraylib/version.py
@@ -1,3 +1,3 @@
 """The version number for Darkgraylib is governed by this file."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
The release of Darkgraylib 2.0.1 is blocking [the Darker 3.0.0 release](https://github.com/akaihola/darker/issues?q=milestone%3A%22Darker+3.0.0+-+Backwards+incompatible+changes%22+sort%3Aupdated-desc) (see akaihola/darker#614).