### PR TITLE
fix: include quiet in baseconfig

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Fixed
 -----
 - Keep Pylint below version 3.3.0 until we drop support for Python 3.8.
 - Don't convert ``log_level = "<string>"`` in the configuration file to an integer.
+- Add the ``quiet = <bool>`` configuration file option.
 
 
 2.0.1_ - 2024-08-09

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -33,14 +33,14 @@ class BaseConfig(TypedDict, total=False):
 
     """
 
-    src: list[str]
-    revision: str
-    stdout: bool
+    color: bool
     config: str
     log_level: int | str
-    color: bool
-    workers: int
     quiet: bool
+    revision: str
+    src: list[str]
+    stdout: bool
+    workers: int
 
 
 class ConfigurationError(Exception):

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -40,6 +40,7 @@ class BaseConfig(TypedDict, total=False):
     log_level: int | str
     color: bool
     workers: int
+    quiet: bool
 
 
 class ConfigurationError(Exception):

--- a/src/darkgraylib/tests/test_config.py
+++ b/src/darkgraylib/tests/test_config.py
@@ -548,6 +548,8 @@ def test_dump_config(config, expect):
         ("workers = 1", {"workers": 1}),
         ("workers = 42", {"workers": 42}),
         ("invalid_option = 42", ConfigurationError),
+        ("quiet = false", {"quiet": False}),
+        ("quiet = true", {"quiet": True}),
     ],
 )
 def test_load_config(tmp_path, monkeypatch, config, expect):


### PR DESCRIPTION
- [x] merge #78 
- [x] merge #79
- [x] add test case for `quiet =` in `test_load_config()`

Included `quiet` in DarkerConfig options.

Also sorted config options alphabetically.

Fixes #76 