### PR TITLE
Don't convert e.g. `log_level = "DEBUG"` to `10` in TOML config file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Added
 Fixed
 -----
 - Keep Pylint below version 3.3.0 until we drop support for Python 3.8.
+- Don't convert ``log_level = "<string>"`` in the configuration file to an integer.
 
 
 2.0.1_ - 2024-08-09

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ These features will be included in the next release:
 
 Added
 -----
+- Unit test for ``log_level`` option for `darkgraylib.config.load_config`.
 
 Fixed
 -----

--- a/src/darkgraylib/config.py
+++ b/src/darkgraylib/config.py
@@ -94,7 +94,7 @@ def validate_config_keys(
 
 def replace_log_level_name(config: BaseConfig) -> None:
     """Replace numeric log level in configuration with the name of the log level"""
-    if "log_level" in config:
+    if "log_level" in config and isinstance(config["log_level"], int):
         config["log_level"] = logging.getLevelName(config["log_level"])
 
 

--- a/src/darkgraylib/tests/test_config.py
+++ b/src/darkgraylib/tests/test_config.py
@@ -6,6 +6,7 @@ from argparse import ArgumentParser, Namespace
 from textwrap import dedent
 
 import pytest
+from toml import TomlDecodeError
 
 from darkgraylib.config import (
     ConfigurationError,
@@ -351,7 +352,7 @@ class OriginTrackingConfig(BaseConfig):
     confpath=None,
     expect={"config": "no_pyp"},
 )
-def test_load_config(  # pylint: disable=too-many-arguments
+def test_load_config_path(  # pylint: disable=too-many-arguments
     tmp_path, monkeypatch, srcs, cwd, confpath, expect
 ):
     """``load_config()`` finds and loads configuration based on source file paths"""
@@ -513,3 +514,38 @@ def test_dump_config(config, expect):
     result = dump_config(config, "darkgraylib")
 
     assert result == expect
+
+
+@pytest.mark.parametrize(
+    ["config", "expect"],
+    [
+        ("", {}),
+        ("log_level = 0", {"log_level": "NOTSET"}),
+        ("log_level = 'NOTSET'", {"log_level": "NOTSET"}),
+        ("log_level = 1", {"log_level": "Level 1"}),
+        ("log_level = 2", {"log_level": "Level 2"}),
+        ("log_level = 10", {"log_level": "DEBUG"}),
+        ("log_level = 'DEBUG'", {"log_level": "DEBUG"}),
+        ("log_level = DEBUG", TomlDecodeError),
+        ("log_level = 20", {"log_level": "INFO"}),
+        ("log_level = 'INFO'", {"log_level": "INFO"}),
+        ("log_level = 30", {"log_level": "WARNING"}),
+        ("log_level = 'WARNING'", {"log_level": "WARNING"}),
+        ("log_level = 40", {"log_level": "ERROR"}),
+        ("log_level = 'ERROR'", {"log_level": "ERROR"}),
+        ("log_level = 50", {"log_level": "CRITICAL"}),
+        ("log_level = 'CRITICAL'", {"log_level": "CRITICAL"}),
+    ],
+)
+def test_load_config(tmp_path, monkeypatch, config, expect):
+    """`load_config()` can load all supported options"""
+    (tmp_path / "pyproject.toml").write_text(f"[tool.darkgraylib]\n{config}\n")
+    monkeypatch.chdir(tmp_path)
+    with raises_if_exception(expect):
+
+        result = load_config(None, ["."], "darkgraylib", BaseConfig)
+
+        assert result == expect
+        assert {k: type(v) for k, v in result.items()} == {
+            k: type(v) for k, v in expect.items()
+        }

--- a/src/darkgraylib/tests/test_config.py
+++ b/src/darkgraylib/tests/test_config.py
@@ -102,7 +102,7 @@ class OriginTrackingConfig(BaseConfig):
     dict(
         srcs=["full_example/full.py"],
         expect={
-            "log_level": 10,
+            "log_level": 'DEBUG',
             "revision": "main",
             "src": ["src", "tests"],
         },


### PR DESCRIPTION
While adding unit tests for configuration file options, I noticed that TOML loading converted string debug levels to integers and integer debug levels to strings. This doesn't make sense of course.