### PR TITLE
Keep Pylint below 3.3.0 until py38 support drop

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,7 +15,7 @@ jobs:
           pip install -U \
             defusedxml \
             pygments \
-            "pylint>=3.3.0" \
+            "pylint<3.3.0" \
             "pytest>=6.2.0" \
             requests \
             requests-cache \

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Keep Pylint below version 3.3.0 until we drop support for Python 3.8.
 
 
 2.0.1_ - 2024-08-09

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ test =
     mypy
     Pygments>=2.4.0
     pydocstyle
-    pylint>=3.3.0
+    pylint<3.3.0
     pytest>=6.2.0
     pytest-kwparametrize>=0.0.3
     requests_cache>=0.7

--- a/src/darkgraylib/argparse_helpers.py
+++ b/src/darkgraylib/argparse_helpers.py
@@ -194,7 +194,7 @@ def generate_options_for_readme(parser: ArgumentParser) -> str:
 class LogLevelAction(Action):  # pylint: disable=too-few-public-methods
     """Support for command line actions which increment/decrement the log level"""
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         option_strings: List[str],
         dest: str,

--- a/src/darkgraylib/tests/test_config.py
+++ b/src/darkgraylib/tests/test_config.py
@@ -351,10 +351,9 @@ class OriginTrackingConfig(BaseConfig):
     confpath=None,
     expect={"config": "no_pyp"},
 )
-def test_load_config(
+def test_load_config(  # pylint: disable=too-many-arguments
     tmp_path, monkeypatch, srcs, cwd, confpath, expect
 ):
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
     """``load_config()`` finds and loads configuration based on source file paths"""
     (tmp_path / ".git").mkdir()
     (tmp_path / "pyproject.toml").write_text('[tool.darkgraylib]\nconfig = "no_pyp"\n')

--- a/src/darkgraylib/tests/test_highlighting.py
+++ b/src/darkgraylib/tests/test_highlighting.py
@@ -1,7 +1,7 @@
 """Unit tests for :mod:`darkgraylib.highlighting`"""
 
-# pylint: disable=protected-access,redefined-outer-name
-# pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
+# pylint: disable=too-many-arguments,redefined-outer-name,unused-argument
+# pylint: disable=protected-access
 
 import os
 import sys

--- a/src/darkgraylib/utils.py
+++ b/src/darkgraylib/utils.py
@@ -28,7 +28,7 @@ class TextDocument:
     DEFAULT_ENCODING = "utf-8"
     DEFAULT_NEWLINE = "\n"
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         string: str = None,
         lines: Iterable[str] = None,


### PR DESCRIPTION
I just forgot that we still have almost a month of Python 3.8 support left, and since Pylint already dropped support for Python 3.8, we need to hold our Pylint upgrades for now.