### PR TITLE
Tools for speeding up tests using Git

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ These features will be included in the next release:
 
 Added
 -----
+- Tools for easy creation of differently scoped Git repository fixtures for tests.
+  Helps speed up parameterized tests that need a Git repository, especially on Windows
+  where Git process forks are comically expensive. The ``test_git.py`` test module now
+  makes use of this and runs in 9s instead of 18s on one Windows laptop.
 - Unit tests of configuration file options for `darkgraylib.config.load_config`.
 
 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ target-version = "py38"
 select = ["ALL"]
 ignore = [
     "ANN101",  # Missing type annotation for `self` in method
+    "COM812",  # Trailing comma missing
     "D203",  # One blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
     "D400",  # First line should end with a period (duplicates D415)
@@ -51,6 +52,7 @@ ignore = [
     "ANN001",  # Missing type annotation for function argument
     "ANN201",  # Missing return type annotation for public function
     "ANN204",  # Missing return type annotation for special method `__init__`
+    "INP001",  # File is part of an implicit namespace package. Add an `__init__.py`.
     "C408",  # Unnecessary `dict` call (rewrite as a literal)
     "S101",  # Use of `assert` detected
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ pygments.lexers =
 pytest11 =
     pytest_git_repo = darkgraylib.testtools.git_repo_plugin
     pytest_clear_black_cache = darkgraylib.testtools.clear_black_cache_plugin
+    pytest_temp_copy = darkgraylib.testtools.temp_copy
     pytest_patching = darkgraylib.testtools.patching
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ pygments.lexers =
 pytest11 =
     pytest_git_repo = darkgraylib.testtools.git_repo_plugin
     pytest_clear_black_cache = darkgraylib.testtools.clear_black_cache_plugin
+    pytest_patching = darkgraylib.testtools.patching
 
 [options.extras_require]
 color =

--- a/src/darkgraylib/tests/test_git.py
+++ b/src/darkgraylib/tests/test_git.py
@@ -1,3 +1,8 @@
+"""Tests for the `darkgraylib.git` module."""
+
+# pylint: disable=redefined-outer-name  # fixtures misfire Pylint's redefinition checks
+# pylint: disable=use-dict-literal  # dict() ok with kwparametrize
+
 import os
 import re
 from datetime import datetime, timedelta
@@ -9,7 +14,7 @@ from unittest.mock import ANY, Mock, call, patch
 import pytest
 
 from darkgraylib import git
-from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
+from darkgraylib.testtools.git_repo_plugin import GitRepoFixture, branched_repo
 from darkgraylib.testtools.helpers import raises_or_matches
 from darkgraylib.utils import GIT_DATEFORMAT, TextDocument
 
@@ -177,6 +182,9 @@ def test_git_get_content_at_revision_obtain_file_content(
         assert text_document_class.method_calls == expect_textdocument_calls
 
 
+git_check_output_lines_repo = pytest.fixture(scope="module")(branched_repo)
+
+
 @pytest.mark.kwparametrize(
     dict(cmd=[], exit_on_error=True, expect_template=CalledProcessError(1, "")),
     dict(
@@ -227,8 +235,11 @@ def test_git_get_content_at_revision_obtain_file_content(
         expect_template=CalledProcessError(128, ""),
     ),
 )
-def test_git_check_output_lines(branched_repo, cmd, exit_on_error, expect_template):
+def test_git_check_output_lines(
+    git_check_output_lines_repo, cmd, exit_on_error, expect_template
+):
     """Unit test for :func:`git_check_output_lines`"""
+    branched_repo = git_check_output_lines_repo
     if isinstance(expect_template, BaseException):
         expect: Union[List[str], BaseException] = expect_template
     else:

--- a/src/darkgraylib/tests/test_git.py
+++ b/src/darkgraylib/tests/test_git.py
@@ -457,6 +457,21 @@ def test_git_clone_local_command(git_clone_local_command_fixture, branch):
     fixture.check_output.assert_has_calls([fixture.post_call])
 
 
+@pytest.fixture(scope="module")
+def git_get_root_repo(request, tmp_path_factory):
+    """Make a Git repository with files in the root and in subdirectories."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        repo.add(
+            {
+                "root.py": "root",
+                "subdir/sub.py": "sub",
+                "subdir/subsubdir/subsub.py": "subsub",
+            },
+            commit="Initial commit",
+        )
+        yield repo
+
+
 @pytest.mark.parametrize(
     "path",
     [
@@ -468,20 +483,11 @@ def test_git_clone_local_command(git_clone_local_command_fixture, branch):
         "subdir/subsubdir/subsub.py",
     ],
 )
-def test_git_get_root(git_repo, path):
-    """``git_get_root()`` returns repository root for any file or directory inside"""
-    git_repo.add(
-        {
-            "root.py": "root",
-            "subdir/sub.py": "sub",
-            "subdir/subsubdir/subsub.py": "subsub",
-        },
-        commit="Initial commit",
-    )
+def test_git_get_root(git_get_root_repo, path):
+    """`git.git_get_root` returns repository root for any file or directory inside."""
+    root = git.git_get_root(git_get_root_repo.root / path)
 
-    root = git.git_get_root(git_repo.root / path)
-
-    assert root == git_repo.root
+    assert root == git_get_root_repo.root
 
 
 @pytest.mark.parametrize(

--- a/src/darkgraylib/testtools/git_repo_plugin.py
+++ b/src/darkgraylib/testtools/git_repo_plugin.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from shutil import rmtree
 from subprocess import check_call  # nosec
-from typing import Dict, Generator, Iterable, List, Union
+from typing import Generator, Iterable
 
 import pytest
 from _pytest.tmpdir import _mk_tmp
@@ -21,7 +21,7 @@ from darkgraylib.git import git_check_output_lines, git_get_version
 class GitRepoFixture:
     """Fixture for managing temporary Git repositories"""
 
-    def __init__(self, root: Path, env: Dict[str, str]):
+    def __init__(self, root: Path, env: dict[str, str]) -> None:
         self.root = root
         self.env = env
 
@@ -67,7 +67,7 @@ class GitRepoFixture:
         yield from cls.tmp_repo(request, tmp_path_factory)
 
     @classmethod
-    def create_repository(cls, root: Path) -> "GitRepoFixture":
+    def create_repository(cls, root: Path) -> GitRepoFixture:
         """Fixture method for creating a Git repository in the given directory"""
         # For testing, ignore ~/.gitconfig settings like templateDir and defaultBranch.
         # Also, this makes sure GIT_DIR or other GIT_* variables are not set, and that
@@ -92,8 +92,10 @@ class GitRepoFixture:
         return git_check_output_lines(list(args), Path(self.root))[0]
 
     def add(
-        self, paths_and_contents: Dict[str, Union[str, bytes, None]], commit: str = None
-    ) -> Dict[str, Path]:
+        self,
+        paths_and_contents: dict[str, str | bytes | None],
+        commit: str | None = None,
+    ) -> dict[str, Path]:
         """Add/remove/modify files and optionally commit the changes
 
         :param paths_and_contents: Paths of the files relative to repository root, and
@@ -148,7 +150,7 @@ class GitRepoFixture:
         """Fixture method to create and check out new branch at given starting point"""
         self._run("checkout", "-b", new_branch, start_point)
 
-    def expand_root(self, lines: Iterable[str]) -> List[str]:
+    def expand_root(self, lines: Iterable[str]) -> list[str]:
         """Replace "{root/<path>}" in strings with the path in the temporary Git repo
 
         This is used to generate expected strings corresponding to locations of files in

--- a/src/darkgraylib/testtools/git_repo_plugin.py
+++ b/src/darkgraylib/testtools/git_repo_plugin.py
@@ -22,6 +22,7 @@ class GitRepoFixture:
     """Fixture for managing temporary Git repositories"""
 
     def __init__(self, root: Path, env: dict[str, str]) -> None:
+        """Use given environment, and directory as the root of the Git repository."""
         self.root = root
         self.env = env
 

--- a/src/darkgraylib/testtools/git_repo_plugin.py
+++ b/src/darkgraylib/testtools/git_repo_plugin.py
@@ -1,12 +1,19 @@
 """Git repository fixture as a Pytest plugin"""
 
+# pylint: disable=no-member  # context managers misfire Pylint's member-checking
+
+from __future__ import annotations
+
 import os
 import re
+from contextlib import contextmanager
 from pathlib import Path
+from shutil import rmtree
 from subprocess import check_call  # nosec
-from typing import Dict, Iterable, List, Union
+from typing import Dict, Generator, Iterable, List, Union
 
 import pytest
+from _pytest.tmpdir import _mk_tmp
 
 from darkgraylib.git import git_check_output_lines, git_get_version
 
@@ -17,6 +24,47 @@ class GitRepoFixture:
     def __init__(self, root: Path, env: Dict[str, str]):
         self.root = root
         self.env = env
+
+    @classmethod
+    def tmp_repo(
+        cls, request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+    ) -> Generator[GitRepoFixture]:
+        """Create temporary Git repository and change current working directory into it.
+
+        This raw function needs to be turned into a fixture using `pytest.fixture` or a
+        context manager using `contextmanager`.
+        Examples::
+
+            git_repo = pytest.fixture(scope="module")(GitRepoFixture._tmp_repo)
+            def test_something(git_repo):
+                assert git_repo.root.is_dir()
+
+            my_fixture = contextmanager(GitRepoFixture._tmp_repo)
+            def test_something_else(request, tmp_path_factory):
+                with my_fixture(request, tmp_path_factory) as git_repo:
+                    assert git_repo.root.is_dir()
+
+        """
+        path = _mk_tmp(request, tmp_path_factory)
+        try:
+            with pytest.MonkeyPatch.context() as mp:
+                repository = cls.create_repository(path)
+                mp.chdir(repository.root)
+                # While `GitRepoFixture.create_repository()` already deletes `GIT_*`
+                # environment variables for any Git commands run by the fixture, let's
+                # explicitly remove `GIT_DIR` in case a test should call Git directly:
+                mp.delenv("GIT_DIR", raising=False)
+                yield repository
+        finally:
+            rmtree(path, ignore_errors=True)
+
+    @classmethod
+    @contextmanager
+    def context(
+        cls, request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+    ) -> Generator[GitRepoFixture]:
+        """Return a context manager for creating a temporary Git repository."""
+        yield from cls.tmp_repo(request, tmp_path_factory)
 
     @classmethod
     def create_repository(cls, root: Path) -> "GitRepoFixture":
@@ -120,22 +168,16 @@ class GitRepoFixture:
         ]
 
 
-@pytest.fixture
-def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GitRepoFixture:
-    """Create a temporary Git repository and change current working directory into it"""
-    repository = GitRepoFixture.create_repository(tmp_path)
-    monkeypatch.chdir(tmp_path)
-    # While `GitRepoFixture.create_repository()` already deletes `GIT_*` environment
-    # variables for any Git commands run by the fixture, let's explicitly remove
-    # `GIT_DIR` in case a test should call Git directly:
-    monkeypatch.delenv("GIT_DIR", raising=False)
-
-    return repository
+git_repo = pytest.fixture(GitRepoFixture.tmp_repo)
+git_repo_m = pytest.fixture(scope="module")(GitRepoFixture.tmp_repo)
 
 
-@pytest.fixture(scope="module")
-def branched_repo(tmp_path_factory: pytest.TempPathFactory) -> GitRepoFixture:
-    """Create an example Git repository with a master branch and a feature branch
+def branched_repo(
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Generator[GitRepoFixture]:
+    """Create an example Git repository with a master branch and a feature branch.
+
+    This raw function needs to be turned into a fixture using `pytest.fixture`.
 
     The history created is::
 
@@ -147,47 +189,46 @@ def branched_repo(tmp_path_factory: pytest.TempPathFactory) -> GitRepoFixture:
         * Initial commit
 
     """
-    tmpdir = tmp_path_factory.mktemp("branched_repo")
-    repo = GitRepoFixture.create_repository(tmpdir)
-    repo.add(
-        {
-            "del_master.py": "original",
-            "del_branch.py": "original",
-            "del_index.py": "original",
-            "del_worktree.py": "original",
-            "mod_master.py": "original",
-            "mod_branch.py": "original",
-            "mod_both.py": "original",
-            "mod_same.py": "original",
-            "keep.py": "original",
-        },
-        commit="Initial commit",
-    )
-    branch_point = repo.get_hash()
-    repo.add(
-        {
-            "del_master.py": None,
-            "add_master.py": "master",
-            "mod_master.py": "master",
-            "mod_both.py": "master",
-            "mod_same.py": "same",
-        },
-        commit="master",
-    )
-    repo.create_branch("branch", branch_point)
-    repo.add(
-        {
-            "del_branch.py": None,
-            "mod_branch.py": "branch",
-            "mod_both.py": "branch",
-            "mod_same.py": "same",
-        },
-        commit="branch",
-    )
-    repo.add(
-        {"del_index.py": None, "add_index.py": "index", "mod_index.py": "index"}
-    )
-    (repo.root / "del_worktree.py").unlink()
-    (repo.root / "add_worktree.py").write_bytes(b"worktree")
-    (repo.root / "mod_worktree.py").write_bytes(b"worktree")
-    return repo
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        repo.add(
+            {
+                "del_master.py": "original",
+                "del_branch.py": "original",
+                "del_index.py": "original",
+                "del_worktree.py": "original",
+                "mod_master.py": "original",
+                "mod_branch.py": "original",
+                "mod_both.py": "original",
+                "mod_same.py": "original",
+                "keep.py": "original",
+            },
+            commit="Initial commit",
+        )
+        branch_point = repo.get_hash()
+        repo.add(
+            {
+                "del_master.py": None,
+                "add_master.py": "master",
+                "mod_master.py": "master",
+                "mod_both.py": "master",
+                "mod_same.py": "same",
+            },
+            commit="master",
+        )
+        repo.create_branch("branch", branch_point)
+        repo.add(
+            {
+                "del_branch.py": None,
+                "mod_branch.py": "branch",
+                "mod_both.py": "branch",
+                "mod_same.py": "same",
+            },
+            commit="branch",
+        )
+        repo.add(
+            {"del_index.py": None, "add_index.py": "index", "mod_index.py": "index"}
+        )
+        (repo.root / "del_worktree.py").unlink()
+        (repo.root / "add_worktree.py").write_bytes(b"worktree")
+        (repo.root / "mod_worktree.py").write_bytes(b"worktree")
+        yield repo

--- a/src/darkgraylib/testtools/patching.py
+++ b/src/darkgraylib/testtools/patching.py
@@ -1,0 +1,17 @@
+"""Helpers for patching in tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+
+@pytest.fixture(scope="module")
+def monkeymodule() -> Iterator[pytest.MonkeyPatch]:
+    """Return a module-scope monkeypatch fixture."""
+    with pytest.MonkeyPatch.context() as monkey_patch:
+        yield monkey_patch

--- a/src/darkgraylib/testtools/temp_copy.py
+++ b/src/darkgraylib/testtools/temp_copy.py
@@ -1,0 +1,31 @@
+"""Pytest fixture factory for making temporary copies of directory trees."""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from shutil import copytree
+from typing import TYPE_CHECKING, Callable, ContextManager
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Generator
+
+
+@pytest.fixture
+def make_temp_copy(
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Callable[[Path], ContextManager[Path]]:
+    """Pytest fixture to create a temporary clone of a directory structure."""
+
+    @contextmanager
+    def temp_copy_factory(path: Path) -> Generator[Path]:
+        max_len = 30
+        name = re.sub(r"\W", "_", f"clone_{request.node.name}")[:max_len]
+        clone = tmp_path_factory.mktemp(name, numbered=True) / path.name
+        copytree(path, clone)
+        yield clone
+
+    return temp_copy_factory


### PR DESCRIPTION
- [x] Git repository factory as a context manager – enables writing Git repository fixtures with different scopes
- [x] Module-scoped Git repository fixture for Pytest (built using the factory above)
- [x] Darkgraylib's own tests sped up using these tools

These tools help speed up parameterized tests which need a Git repository, especially on Windows where forked processes are comically expensive.

See akaihola/darker#761 and akaihola/graylint#68 for usages of these tools.