### PR TITLE
Update `install-nix-action`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,7 +63,7 @@ jobs:
       - build-wheel
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Download wheel uploaded by the build-wheel job

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Update Nix action to v31 – fixes the build error.
 
 
 2.4.0_ - 2025-06-10


### PR DESCRIPTION
fix(ci): update install-nix-action to v31

v22 would fail with "This version of Nixpkgs requires an implementation of Nix with the following features: - `builtins.nixVersion` reports at least 2.18. Your are evaluating with Nix 2.16.1, please upgrade"